### PR TITLE
Add ability to modify selected signal

### DIFF
--- a/dev/fulcrum/signal_pm/data_events.js
+++ b/dev/fulcrum/signal_pm/data_events.js
@@ -17,6 +17,14 @@ var request_attempts = 0;
 //  if no signal found within search distance, get all signals
 ON('load-record', getLocation);
 
+ON('change', 'clear_signal', function(event) {
+    if (event.value == "yes") {
+        SETVALUE('signal', '');
+        getSignal({"longitude" : "-97.74306", "latitude":"-30.26715"}, get_all==true); 
+        SETVALUE('clear_signal', '');
+    }
+})
+
 function getLocation(){
     //  attempt to get location when record loads
     //  stop when location is found, or after specified SETIMEOUT
@@ -26,7 +34,7 @@ function getLocation(){
 
         if (location) {
             CLEARINTERVAL(interval);
-            getSignal(location);
+            getSignal(location, get_all=true);
         }
 
     }, 1000);

--- a/dev/fulcrum/signal_pm/data_events.js
+++ b/dev/fulcrum/signal_pm/data_events.js
@@ -24,10 +24,9 @@ var ALL_SIGNALS_RETRIEVED = false;
 //  if no signal found within search distance, get all signals
 ON('load-record', getLocation);
 
-ON('click', 'clear_signal_new', function(event) {
+ON('click', 'clear_signal', function(event) {
     SETVALUE('signal', '');
-    getSignal({"longitude" : "-97.743", "latitude":"30.267"}); 
-    SETVALUE('clear_signal', '');
+    getSignal({"longitude" : "-97.743", "latitude":"30.267"});
 })
 
 function getLocation(){

--- a/dev/fulcrum/signal_pm/data_events.js
+++ b/dev/fulcrum/signal_pm/data_events.js
@@ -1,0 +1,121 @@
+function setStatus() {
+  SETSTATUS('completed')
+}
+
+// config
+var signals = { 
+    'id' : 'xwqn-2f78',
+    'label_field' : 'location_name',
+    'value_field' : 'signal_id',
+    'search_distance' : 200,  //  meters
+};
+
+//  use to limit looping socrata request attempts
+var request_attempts = 0;
+
+//  get nearest signal
+//  if no signal found within search distance, get all signals
+ON('load-record', getLocation);
+
+function getLocation(){
+    //  attempt to get location when record loads
+    //  stop when location is found, or after specified SETIMEOUT
+    var interval = SETINTERVAL(function() {
+
+        var location = CURRENTLOCATION();
+
+        if (location) {
+            CLEARINTERVAL(interval);
+            getSignal(location);
+        }
+
+    }, 1000);
+
+    SETTIMEOUT(function() {
+        CLEARINTERVAL(interval);
+    }, 10000);
+
+}
+
+
+function getSignal(location, get_all=false) {
+    //  get nearby signals from socrata and set selection choices
+    var search_distance = signals.search_distance;
+
+    if (get_all) {
+        search_distance = 100000;
+    }
+
+    var url = 'https://data.austintexas.gov/resource/' + signals.id + '.json';
+
+    var options = buildRequestParams(
+        url,
+        location['latitude'],
+        location['longitude'],
+        search_distance=search_distance
+    );
+    
+    //  show modal
+    PROGRESS('Searching for nearby signals...');
+
+    REQUEST(options, function(error, response, body) {
+        //  Exec this function after GET data from socrata endpoint
+
+        //  hide progress modal
+        PROGRESS();
+
+        if (error) {
+            ALERT('Error with request: ' + options.url);
+        } else {
+            var data = JSON.parse(body);
+            if (data.length) {
+                //  populate field selection choices with features
+                var choices = getChoices(signals.label_field, signals.value_field, data);
+                SETCHOICES('signal', choices);
+
+                if (!$signal) {
+                    //  if there is no signal selected
+                    //  set field label and value to nearest feature (ie the first one)
+                    // SETVALUE('signal', choices[0][0]);
+                    SETVALUE('signal', choices[0]);
+                };
+
+            } else {
+                if (request_attempts < 1) {
+                    request_attempts++;
+                    getSignal(location, get_all=true);
+                }
+            }
+        }
+
+    });
+
+}
+
+
+function buildRequestParams(url, lat, lon, search_distance=2000) {
+    //  Format request parameters accoring to Socrata query API
+    //  Defined here: https://dev.socrata.com/docs/queries/
+
+    // select distance from point to each signal and sort by closest
+    var select = '?$query=SELECT signal_id, location_name, DISTANCE_IN_METERS(location, \'POINT(' + lon + ' ' + lat + ')\') AS distance';
+    return url + select + ' WHERE control=\'PRIMARY\' and WITHIN_CIRCLE(location, ' + lat + ', ' + lon + ', ' + search_distance + ') ORDER BY distance ASC';    
+}
+
+
+function getChoices(label_field, value_field, choice_data) {
+    var choices = [];
+
+    //  format response data as array of fulcrum-friendly selection choices
+    for (var i=0; i < choice_data.length; i++) {
+        var label = choice_data[i][label_field];
+        var value = choice_data[i][value_field];
+        // choices.push([label, value]);
+
+        //  we combine label/value to one field
+        //  because SETVALUE only takes a string (not an array of label/value pairs)
+        choices.push( value + ' | ' + label );
+    }
+
+    return choices;
+}


### PR DESCRIPTION
Fixes #499.

The fulcrum Signal PM app attempts to find the nearest traffic signal based on the user's location. However, once the choice list of nearby signals had been populated, the user could only select one of the nearby signals. There was no mechanism to populate the choice list with all signals. This was an issue when, say, a technician was completing the PM offsite.

We've updated the app with a button that says "Clear Selected Signal", and this PR updates the data event JS to handle that button press by clearing the value in the `signal` field and fetching all signals in the city.

![thumbnail_image1](https://user-images.githubusercontent.com/14793120/63189684-25fce180-c02a-11e9-92ce-094f83d08043.png)
