### PR TITLE
Add GitHub Actions workflow to assign projects based on DTS Team issue field

### DIFF
--- a/.github/workflows/team-issue-field-project-linker.yml
+++ b/.github/workflows/team-issue-field-project-linker.yml
@@ -1,0 +1,52 @@
+name: Assign Project based on DTS Team issue field
+
+on:
+  issues:
+    types: [field_added, field_removed]
+
+jobs:
+  log-dts-team:
+    if: github.event.issue_field.name == 'DTS Team'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log DTS Team value
+        run: |
+          echo 'Action: ${{ github.event.action }}'
+          echo 'Value: ${{ github.event.issue_field_value.option.name }}'
+
+  add-to-team-project:
+    if: >-
+      github.event.issue_field.name == 'DTS Team' &&
+      github.event.action == 'field_added'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look up project number for team
+        id: lookup
+        env:
+          TEAM: ${{ github.event.issue_field_value.option.name }}
+        run: |
+          declare -A DTS_TEAMS=(
+            ["Apps"]=16
+            ["Data Science"]=19
+            ["Dev"]=25
+            ["ECM"]=22
+            ["Geo"]=6
+            ["Maximo"]=18
+            ["Product"]=23
+            ["Tech Services"]=21
+            ["Operations"]=20
+          )
+          number="${DTS_TEAMS[$TEAM]}"
+          if [ -z "$number" ]; then
+            echo "No project mapped for team '$TEAM'; skipping."
+            echo "project-number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "project-number=$number" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add issue to team project
+        if: steps.lookup.outputs.project-number != ''
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/cityofaustin/projects/${{ steps.lookup.outputs.project-number }}
+          github-token: ${{ secrets.PROJECT_MANAGEMENT_PAT }}

--- a/.github/workflows/team-issue-field-project-linker.yml
+++ b/.github/workflows/team-issue-field-project-linker.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   log-dts-team:
-    if: github.event.issue_field.name == 'DTS Team'
+    if: >-
+      github.event.issue_field.name == 'DTS Team' &&
+      github.event.issue.type.name == 'Task'
     runs-on: ubuntu-latest
     steps:
       - name: Log DTS Team value
@@ -17,7 +19,8 @@ jobs:
   add-to-team-project:
     if: >-
       github.event.issue_field.name == 'DTS Team' &&
-      github.event.action == 'field_added'
+      github.event.action == 'field_added' &&
+      github.event.issue.type.name == 'Task'
     runs-on: ubuntu-latest
     steps:
       - name: Look up project number for team

--- a/.github/workflows/team-issue-field-project-linker.yml
+++ b/.github/workflows/team-issue-field-project-linker.yml
@@ -2,7 +2,7 @@ name: Assign Project based on DTS Team issue field
 
 on:
   issues:
-    types: [field_added, field_removed]
+    types: [field_added]
 
 jobs:
   log-dts-team:
@@ -19,7 +19,6 @@ jobs:
   add-to-team-project:
     if: >-
       github.event.issue_field.name == 'DTS Team' &&
-      github.event.action == 'field_added' &&
       github.event.issue.type.name == 'Task'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/team-issue-field-project-linker.yml
+++ b/.github/workflows/team-issue-field-project-linker.yml
@@ -8,7 +8,7 @@ jobs:
   log-dts-team:
     if: >-
       github.event.issue_field.name == 'DTS Team' &&
-      github.event.issue.type.name == 'Task'
+      contains(fromJSON('["Task","Product","Service"]'), github.event.issue.type.name)
     runs-on: ubuntu-latest
     steps:
       - name: Log DTS Team value
@@ -19,7 +19,7 @@ jobs:
   add-to-team-project:
     if: >-
       github.event.issue_field.name == 'DTS Team' &&
-      github.event.issue.type.name == 'Task'
+      contains(fromJSON('["Task","Product","Service"]'), github.event.issue.type.name)
     runs-on: ubuntu-latest
     steps:
       - name: Look up project number for team


### PR DESCRIPTION
# Issue

https://github.com/cityofaustin/atd-data-tech/issues/29101

# Intent

When the issue field 'DTS Team' is set, add the issue to the correct GitHub project.

# Testing

Testing in this repo is challenging because we're working with events that are not tied to a git ref, so we have to have the workflow in the main branch for it to be picked up. I have done my development in https://github.com/cityofaustin/dts-data-tech-dev so that is a better place to test this workflow.

* In the above repo, either use the existing test issue or create a new one. If you do create a new one, be sure to set the issue type to 'Task' so you get the issue fields that you'll want to interact with.
* Interact with the Issue field `DTS Team`. When you set it to a value, does the issue get put in the correct project?
* Is it OK that it does not remove an issue from a project when you unset the `DTS Team` field?
  * You can manually remove an issue from a project using the little ⚙️ icon to the upper right of the projects section of the issue.